### PR TITLE
Adjust available page sizes to reduce CPU render calcs

### DIFF
--- a/imports/ui/searchResults.jsx
+++ b/imports/ui/searchResults.jsx
@@ -393,8 +393,8 @@ return null
                   <ReactTable
                       data={data}
                       columns={columns}
-                      defaultPageSize={data.length}
-                      pageSizeOptions={[100, 1000, 10000]}
+                      defaultPageSize={20}
+                      pageSizeOptions={[5, 10, 20, 25, 50, 100]}
                       filterable={true}
                       defaultFilterMethod ={(filter, row) => filterMethod(filter, row)}
                   />


### PR DESCRIPTION
It looks like the default page size is too large -> tannerlinsley/react-table#700 (comment) hints at the visible (page size) needs to be relatively low (maybe 5-10-20 per page). It can still sort and filter on the whole result set as it's mostly done virtually (without any render).

I've taken the available options from one of the examples on the site `[5, 10, 20, 25, 50, 100]`