### PR TITLE
Replace sort checkboxes with a select component

### DIFF
--- a/imports/ui/components/SelectInput.jsx
+++ b/imports/ui/components/SelectInput.jsx
@@ -1,0 +1,32 @@
+import { Form } from "react-bootstrap";
+import React from "react";
+
+export class SelectInput extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+  
+  getOptions() {
+    let res = [];
+    
+    for (const [key, value] of Object.entries(this.props.items)) {
+      res.push(<option key={key} value={key}>{value}</option>);
+    }
+
+    return res;
+  }
+  
+  render() {
+    return (
+      <Form>
+        <Form.Control 
+          as="select" 
+          onChange={this.props.onChangeHandler}
+          className={"selectInput " + this.props.className}
+        >
+        {this.getOptions()}
+        </Form.Control>
+      </Form>
+      )
+    }
+  }

--- a/imports/ui/components/SortSelect.jsx
+++ b/imports/ui/components/SortSelect.jsx
@@ -1,0 +1,40 @@
+import { SelectInput } from "./SelectInput";
+import { GlobalSettingsDB } from "../../api/database.js";
+import React from "react";
+
+export class SortSelect extends React.Component {
+  constructor(props) {
+    super(props);
+    
+    this.state = {
+      sortOptions: {
+        sortDateOldest: "Oldest (Scanned):",
+        sortDateNewest: "Newest (Scanned):",
+        sortDateFileCreatedOldest: "Oldest (Created):",
+        sortDateFileCreatedNewest: "Newest (Created):",
+        sortDateFileModifiedOldest: "Oldest (Modified):",
+        sortDateFileModifiedNewest: "Newest (Modified):",
+        sortSizeSmallest: "Smallest:",
+        sortSizeLargest: "Largest:"
+      }
+    }
+  }
+  
+  setSort(event) {
+    GlobalSettingsDB.upsert("globalsettings", {
+      $set: {
+        queueSortType: event.target.value
+      }
+    });
+  }
+  
+  render() {
+    return (
+      <SelectInput
+      items={this.state.sortOptions}
+      onChangeHandler={this.setSort}
+      className="queueSortSelect"
+      />
+      )
+    }
+  }

--- a/imports/ui/components/SortSelect.jsx
+++ b/imports/ui/components/SortSelect.jsx
@@ -8,14 +8,14 @@ export class SortSelect extends React.Component {
     
     this.state = {
       sortOptions: {
-        sortDateOldest: "Oldest (Scanned):",
-        sortDateNewest: "Newest (Scanned):",
-        sortDateFileCreatedOldest: "Oldest (Created):",
-        sortDateFileCreatedNewest: "Newest (Created):",
-        sortDateFileModifiedOldest: "Oldest (Modified):",
-        sortDateFileModifiedNewest: "Newest (Modified):",
-        sortSizeSmallest: "Smallest:",
-        sortSizeLargest: "Largest:"
+        sortDateOldest: "Oldest (Scanned)",
+        sortDateNewest: "Newest (Scanned)",
+        sortDateFileCreatedOldest: "Oldest (Created)",
+        sortDateFileCreatedNewest: "Newest (Created)",
+        sortDateFileModifiedOldest: "Oldest (Modified)",
+        sortDateFileModifiedNewest: "Newest (Modified)",
+        sortSizeSmallest: "Smallest",
+        sortSizeLargest: "Largest"
       }
     }
   }

--- a/imports/ui/styles/main.scss
+++ b/imports/ui/styles/main.scss
@@ -1420,6 +1420,14 @@ table.streamsTable tr {
 
 .queueSortSelect {
   max-width: 300px;
+  color:white;
+  background-color: #222222;
+  border: solid 1px white;
+}
+
+.queueSortSelect:focus {
+  color:white;
+  background-color: #222222;
 }
 
 /* Tabs */

--- a/imports/ui/styles/main.scss
+++ b/imports/ui/styles/main.scss
@@ -1418,13 +1418,9 @@ table.streamsTable tr {
 
 }
 
-
-
-
-
-
-
-
+.queueSortSelect {
+  max-width: 300px;
+}
 
 /* Tabs */
 

--- a/imports/ui/transcoding/tab_Transcoding.jsx
+++ b/imports/ui/transcoding/tab_Transcoding.jsx
@@ -15,6 +15,7 @@ import {
 import Workers from "./tab_Transcoding_Worker.jsx";
 import ReactTable from "react-table";
 import Slider from "react-input-slider";
+import { SortSelect } from "../components/SortSelect.jsx";
 import ItemButton from "../item_Button.jsx";
 import ClipLoader from "react-spinners/ClipLoader";
 import Checkbox from "@material-ui/core/Checkbox";
@@ -155,25 +156,6 @@ class App extends Component {
     ));
   }
 
-  renderSortBox(type) {
-    return this.props.globalSettings.map((item, i) => (
-      <Checkbox
-        name={type}
-        checked={item.queueSortType == type ? true : false}
-        onChange={this.setSort}
-      />
-    ));
-  }
-
-  setSort(event) {
-    if (event.target.checked == true) {
-      GlobalSettingsDB.upsert("globalsettings", {
-        $set: {
-          queueSortType: event.target.name,
-        },
-      });
-    }
-  }
 
   renderCheckBox = (type) => {
     return this.props.globalSettings.map((item, i) => (
@@ -1081,25 +1063,7 @@ class App extends Component {
           </Modal>
 
           <p>Sort queue by: </p>
-          <p>
-            Oldest (Scanned):
-            {this.renderSortBox("sortDateOldest")}
-            Newest (Scanned):
-            {this.renderSortBox("sortDateNewest")}
-            Oldest (Created):
-            {this.renderSortBox("sortDateFileCreatedOldest")}
-            Newest (Created):
-            {this.renderSortBox("sortDateFileCreatedNewest")}
-            Oldest (Modified):
-            {this.renderSortBox("sortDateFileModifiedOldest")}
-            Newest (Modified):
-            {this.renderSortBox("sortDateFileModifiedNewest")}
-            Smallest:
-            {this.renderSortBox("sortSizeSmallest")}
-            Largest:
-            {this.renderSortBox("sortSizeLargest")}
-          </p>
-
+          <SortSelect></SortSelect>
           <p>
             Library alternation: {this.renderCheckBox("alternateLibraries")}
           </p>


### PR DESCRIPTION
I set the `max-width` to `300px` for now but I think that should be reworked to something more responsive down the line :p

Changes:
Adds a new generic select input (dropdown) component
Adds a specific dropdown component for queue sort

Before:
![image](https://user-images.githubusercontent.com/6439218/86534733-0ccb8080-bedb-11ea-8e95-6a106ef4fcfe.png)

After: 
![image](https://user-images.githubusercontent.com/6439218/86534730-fcb3a100-beda-11ea-81f9-f5454c9f2704.png)

