### PR TITLE
Update readme to reflect change in open-source status

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Audio/Video Library Analytics & Transcode/Remux Automation
 
 <h2>About:</h2>  
 
-Tdarr V2 is a distributed transcoding system for automating media library transcode/remux management and making sure your files are exactly how you need them to be in terms of codecs/streams/containers and so on. Put your spare hardware to use with Tdarr Nodes for Windows, Linux (including Linux arm) and macOS.
+Tdarr V2 is a closed-source distributed transcoding system for automating media library transcode/remux management and making sure your files are exactly how you need them to be in terms of codecs/streams/containers and so on. Put your spare hardware to use with Tdarr Nodes for Windows, Linux (including Linux arm) and macOS. Code in this repository is for Tdarr V1, Tdarr V2 is not open-source.
 
 Designed to work alongside applications like Sonarr/Radarr and built with the aim of modularisation, parallelisation and scalability, each library you add has its own transcode settings, filters and schedule. Workers can be fired up and closed down as necessary, and are split into 4 types - Transcode CPU/GPU and Health Check CPU/GPU. Worker limits can be managed by the scheduler as well as manually. For a desktop application with similar functionality please see [HBBatchBeast](https://github.com/HaveAGitGat/HBBatchBeast).
 


### PR DESCRIPTION
Make it clear that Tdarr V2 is not open source.