### PR TITLE
Add Intel Arc hardware acceleration support.

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,11 +1,11 @@
-FROM lsiobase/ubuntu:focal
+FROM lsiobase/ubuntu:jammy
 
 ENV \
  LIBVA_DRIVERS_PATH="/usr/lib/x86_64-linux-gnu/dri" \
  LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu" \
  NVIDIA_DRIVER_CAPABILITIES="compute,video,utility" \
  NVIDIA_VISIBLE_DEVICES="all" \
- HANDBRAKE=1.6.1
+ HANDBRAKE=1.7.3
 
 ENV WEB_UI_PORT="8265" SERVER_PORT="8266" NODE_PORT="8267" PUID="1000" PGID="1000" UMASK="002" TZ="Etc/UTC" HOME="/home/Tdarr"
 
@@ -13,23 +13,27 @@ COPY docker/root/ /
 
 # handle deps
 RUN apt-get update &&  \
-        apt-get install -y \
-            software-properties-common \
-            git \
-            trash-cli && \
-    mkdir -p \
-    /app \
-    /logs \
-    /temp \
-    "${HOME}" && \
-    # useradd -u ${PUID} -U -d ${HOME} -s /bin/false Tdarr && \
-    # usermod -G users Tdarr && \
-    
-    apt-get update && \
-    apt-get install -y curl unzip mkvtoolnix && \
-    #cc-extractor
     apt-get install -y \
-        cargo \
+        software-properties-common \
+        git \
+        trash-cli
+
+RUN mkdir -p \
+        /app \
+        /logs \
+        /temp \
+        "${HOME}"
+    
+RUN apt-get update && \
+    apt-get install -y \
+        curl \
+        unzip \
+        mkvtoolnix
+
+# CCExtractor dependencies
+RUN apt-get update && \
+    apt-get install -y \
+        libgpac-dev \
         libglew-dev \
         libglfw3-dev \
         cmake \
@@ -39,58 +43,80 @@ RUN apt-get update &&  \
         libtesseract-dev \
         libleptonica-dev \
         clang \
-        libclang-dev && \
-        git clone https://github.com/CCExtractor/ccextractor.git && \
-        cd ccextractor/linux && \ 
-        ./build -without-rust && \
-        mv ./ccextractor /usr/bin/ccextractor && \
-        
-        cd / && rm -rf /ccextractor && \
-    if uname -m | grep -q x86; then \
+        libclang-dev
 
-        # b
-        apt-get install -y gpg-agent wget && \
-        wget -qO - https://repositories.intel.com/graphics/intel-graphics.key | \
-        gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg && \
-        echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/graphics/ubuntu focal-legacy main' | \
-        tee  /etc/apt/sources.list.d/intel.gpu.focal.list && \
+# CCExtractor
+RUN git clone --branch v0.94 https://github.com/CCExtractor/ccextractor.git && \
+    cd ccextractor/linux && \ 
+    ./build -without-rust && \
+    mv ./ccextractor /usr/bin/ccextractor && \
+    cd / && rm -rf /ccextractor
 
-        # FFmpeg
-        apt install -y wget && \
-        wget https://repo.jellyfin.org/releases/server/ubuntu/versions/jellyfin-ffmpeg/6.0-1/jellyfin-ffmpeg6_6.0-1-focal_amd64.deb && \
+# Setup Intel Package Repository
+RUN if uname -m | grep -q x86; then \
+        curl -sSL https://repositories.intel.com/gpu/intel-graphics.key | \
+            gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg && \
+        echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy client" | \
+            tee /etc/apt/sources.list.d/intel-gpu-jammy.list && \
+        apt-get update ; \
+    fi
+
+# Install Intel Compute, Media and Display runtimes
+RUN if uname -m | grep -q x86; then \
         apt install -y \
-        ./jellyfin-ffmpeg6_6.0-1-focal_amd64.deb && \
-        rm -rf ./jellyfin-ffmpeg6_6.0-1-focal_amd64.deb && \
-        ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg && \
-        ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/tdarr-ffmpeg && \
-        # apt-get install -y ffmpeg && \
-     
-        apt-get update && \
-
-        # b
-        apt-get install -y \
             intel-opencl-icd \
-            intel-level-zero-gpu level-zero \
-            intel-media-va-driver-non-free libmfx1 libmfxgen1 libvpl2 && \
-
-        apt-get install -y --no-install-recommends \
+            intel-level-zero-gpu \
+            level-zero \
             intel-media-va-driver-non-free \
+            libmfx1 \
+            libmfxgen1 \
+            libvpl2 \
+            libegl-mesa0 \
+            libegl1-mesa \
+            libegl1-mesa-dev \
+            libgbm1 \
+            libgl1-mesa-dev \
+            libgl1-mesa-dri \
+            libglapi-mesa \
+            libgles2-mesa-dev \
+            libglx-mesa0 \
+            libigdgmm12 \
+            libxatracker2 \
+            mesa-va-drivers \
+            mesa-vdpau-drivers \
+            mesa-vulkan-drivers \
+            va-driver-all \
             vainfo \
-            mesa-va-drivers && \
+            hwinfo \
+            clinfo ; \
+    fi
 
-        # HandBrake deps
+# FFmpeg
+RUN if uname -m | grep -q x86; then \
+        # curl -LO https://repo.jellyfin.org/releases/server/ubuntu/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-focal_amd64.deb && \
+        # apt-get install -y \
+        # ./jellyfin-ffmpeg6_6.0.1-3-focal_amd64.deb && \
+        # rm -rf ./jellyfin-ffmpeg6_6.0.1-3-focal_amd64.deb && \
+        # ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg && \
+        # ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/tdarr-ffmpeg ; \
+        apt update && \
+        apt install -y \
+            ffmpeg ; \
+    fi
+
+# HandBrake dependencies
+RUN if uname -m | grep -q x86; then \
+        apt-get update && \
         apt-get install -y \
             autoconf \
             automake \
-            autopoint \
-            appstream \
             build-essential \
             cmake \
             git \
             libass-dev \
             libbz2-dev \
-            libfontconfig1-dev \
-            libfreetype6-dev \
+            libfontconfig-dev \
+            libfreetype-dev \
             libfribidi-dev \
             libharfbuzz-dev \
             libjansson-dev \
@@ -99,7 +125,7 @@ RUN apt-get update &&  \
             libnuma-dev \
             libogg-dev \
             libopus-dev \
-            libsamplerate-dev \
+            libsamplerate0-dev \
             libspeex-dev \
             libtheora-dev \
             libtool \
@@ -116,14 +142,15 @@ RUN apt-get update &&  \
             ninja-build \
             patch \
             pkg-config \
-            python \
             tar \
             zlib1g-dev \
+            # QSV dependencies
             libva-dev \
-            libdrm-dev \
-            libmfx-dev \
-            libmfx1 && \
+            libdrm-dev ; \
+    fi
 
+# HandBrake install
+RUN if uname -m | grep -q x86; then \
         rm -rdf /tmp/handbrake && \
         mkdir -p /tmp/handbrake && \
         git clone \
@@ -142,12 +169,14 @@ RUN apt-get update &&  \
         make --directory=build install && \
         cp /tmp/handbrake/build/HandBrakeCLI /usr/local/bin/HandBrakeCLI && \
         rm -rdf /tmp/handbrake/ ; \
-    fi && \
-    if uname -m | grep -q aarch64; then \
+    fi
+
+RUN if uname -m | grep -q aarch64; then \
         apt-get install -y handbrake-cli ffmpeg && \
         ln -s /usr/bin/ffmpeg /usr/local/bin/tdarr-ffmpeg ; \
-    fi && \
-    if uname -m | grep -q armv7l; then \
+    fi
+
+RUN if uname -m | grep -q armv7l; then \
         apt-get install -y handbrake-cli ffmpeg && \
         ln -s /usr/bin/ffmpeg /usr/local/bin/tdarr-ffmpeg ; \
     fi

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -9,31 +9,27 @@ ENV \
 
 ENV WEB_UI_PORT="8265" SERVER_PORT="8266" NODE_PORT="8267" PUID="1000" PGID="1000" UMASK="002" TZ="Etc/UTC" HOME="/home/Tdarr"
 
-COPY docker/root/ /
-
 # handle deps
 RUN apt-get update &&  \
-    apt-get install -y \
-        software-properties-common \
-        git \
-        trash-cli
-
-RUN mkdir -p \
-        /app \
-        /logs \
-        /temp \
-        "${HOME}"
+        apt-get install -y \
+            software-properties-common \
+            git \
+            trash-cli && \
+    mkdir -p \
+    /app \
+    /logs \
+    /temp \
+    "${HOME}" && \
+    # useradd -u ${PUID} -U -d ${HOME} -s /bin/false Tdarr && \
+    # usermod -G users Tdarr && \
     
-RUN apt-get update && \
+    apt-get update && \
+    apt-get install -y curl unzip mkvtoolnix comskip \
+        # for apprise
+        python3-pip && \
+        pip3 install apprise && \
+    #cc-extractor
     apt-get install -y \
-        curl \
-        unzip \
-        mkvtoolnix
-
-# CCExtractor dependencies
-RUN apt-get update && \
-    apt-get install -y \
-        libgpac-dev \
         libglew-dev \
         libglfw3-dev \
         cmake \
@@ -43,26 +39,24 @@ RUN apt-get update && \
         libtesseract-dev \
         libleptonica-dev \
         clang \
-        libclang-dev
-
-# CCExtractor
-RUN git clone --branch v0.94 https://github.com/CCExtractor/ccextractor.git && \
-    cd ccextractor/linux && \ 
-    ./build -without-rust && \
-    mv ./ccextractor /usr/bin/ccextractor && \
-    cd / && rm -rf /ccextractor
+        libclang-dev && \
+        # libgpac-dev && \
+        git clone https://github.com/CCExtractor/ccextractor.git && \
+        cd ccextractor/linux && \ 
+        git checkout 35e73c1c90ce3ca69394d3523836bb1cdec28f11 && \
+        ./build -without-rust && \
+        mv ./ccextractor /usr/bin/ccextractor && \
+        
+        cd / && rm -rf /ccextractor && \
+    if uname -m | grep -q x86; then \
 
 # Setup Intel Package Repository
-RUN if uname -m | grep -q x86; then \
         curl -sSL https://repositories.intel.com/gpu/intel-graphics.key | \
             gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg && \
         echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy client" | \
             tee /etc/apt/sources.list.d/intel-gpu-jammy.list && \
-        apt-get update ; \
-    fi
+        apt-get update && \
 
-# Install Intel Compute, Media and Display runtimes
-RUN if uname -m | grep -q x86; then \
         apt install -y \
             intel-opencl-icd \
             intel-level-zero-gpu \
@@ -88,25 +82,20 @@ RUN if uname -m | grep -q x86; then \
             va-driver-all \
             vainfo \
             hwinfo \
-            clinfo ; \
-    fi
+            clinfo && \
 
-# FFmpeg
-RUN if uname -m | grep -q x86; then \
-        # curl -LO https://repo.jellyfin.org/releases/server/ubuntu/versions/jellyfin-ffmpeg/6.0.1-3/jellyfin-ffmpeg6_6.0.1-3-focal_amd64.deb && \
-        # apt-get install -y \
-        # ./jellyfin-ffmpeg6_6.0.1-3-focal_amd64.deb && \
-        # rm -rf ./jellyfin-ffmpeg6_6.0.1-3-focal_amd64.deb && \
-        # ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg && \
-        # ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/tdarr-ffmpeg ; \
-        apt update && \
+        # FFmpeg 6
         apt install -y \
-            ffmpeg ; \
-    fi
-
-# HandBrake dependencies
-RUN if uname -m | grep -q x86; then \
-        apt-get update && \
+        wget && \
+        ffmpegversion=$(curl --silent https://api.github.com/repos/jellyfin/jellyfin-ffmpeg/releases/latest | grep -oP '"tag_name":\s*"v\K[^"]+' | sort -h | tail -n1) && \
+        wget https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v$ffmpegversion/jellyfin-ffmpeg6_$ffmpegversion-jammy_amd64.deb && \
+        apt install -y \
+        ./jellyfin-ffmpeg6_$ffmpegversion-jammy_amd64.deb && \
+        rm -rf ./jellyfin-ffmpeg6_$ffmpegversion-jammy_amd64.deb && \
+        ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg && \
+        ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/tdarr-ffmpeg && \
+        # apt-get install -y ffmpeg && \
+        # HandBrake dependencies
         apt-get install -y \
             autoconf \
             automake \
@@ -114,6 +103,7 @@ RUN if uname -m | grep -q x86; then \
             cmake \
             git \
             libass-dev \
+            libass9 \
             libbz2-dev \
             libfontconfig-dev \
             libfreetype-dev \
@@ -142,15 +132,13 @@ RUN if uname -m | grep -q x86; then \
             ninja-build \
             patch \
             pkg-config \
+            # python \
             tar \
             zlib1g-dev \
             # QSV dependencies
             libva-dev \
-            libdrm-dev ; \
-    fi
+            libdrm-dev && \
 
-# HandBrake install
-RUN if uname -m | grep -q x86; then \
         rm -rdf /tmp/handbrake && \
         mkdir -p /tmp/handbrake && \
         git clone \
@@ -169,14 +157,34 @@ RUN if uname -m | grep -q x86; then \
         make --directory=build install && \
         cp /tmp/handbrake/build/HandBrakeCLI /usr/local/bin/HandBrakeCLI && \
         rm -rdf /tmp/handbrake/ ; \
-    fi
-
-RUN if uname -m | grep -q aarch64; then \
+    fi && \
+    if uname -m | grep -q aarch64; then \
         apt-get install -y handbrake-cli ffmpeg && \
         ln -s /usr/bin/ffmpeg /usr/local/bin/tdarr-ffmpeg ; \
-    fi
-
-RUN if uname -m | grep -q armv7l; then \
+    fi && \
+    if uname -m | grep -q armv7l; then \
         apt-get install -y handbrake-cli ffmpeg && \
         ln -s /usr/bin/ffmpeg /usr/local/bin/tdarr-ffmpeg ; \
-    fi
+    fi && \
+
+    trash-empty && \
+        if uname -m | grep -q x86; then \
+            apt-get clean && \
+            apt purge -y \
+                g++-9 \
+                gcc-9 \
+                # libc6-dev \
+                libstdc++-9-dev \
+                cpp-9 \
+                libgcc-9-dev \
+                libstd-rust-dev \
+                # libllvm12 \
+                libicu-dev \
+                cargo \
+                libstd-rust-1.65 \
+                libstd-rust-dev \
+                git \
+                cmake \
+                python3-pip ; \
+        fi && \
+    apt autoremove -y


### PR DESCRIPTION
This PR addresses #902.

It updates Dockerfile.base to jammy and adds the latest media runtime (and probably some unrequired dependencies).
Unfortunately, I can't test Dockerfile.final, but in Dockerfile.base I can transcode with HandBreakCLI  using my Arc A380.

Let me know if I can assist with testing the final build. 