### PR TITLE
Update Flatpak metadata for 2.79.01

### DIFF
--- a/flatpak/io.tdarr.Tdarr_Node.metainfo.xml
+++ b/flatpak/io.tdarr.Tdarr_Node.metainfo.xml
@@ -25,6 +25,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="2.79.01" date="2026-06-21" />
     <release version="2.78.01" date="2026-06-12" />
     <release version="2.77.01" date="2026-05-29" />
     <release version="2.76.01" date="2026-05-27" />

--- a/flatpak/io.tdarr.Tdarr_Server.metainfo.xml
+++ b/flatpak/io.tdarr.Tdarr_Server.metainfo.xml
@@ -29,6 +29,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="2.79.01" date="2026-06-21" />
     <release version="2.78.01" date="2026-06-12" />
     <release version="2.77.01" date="2026-05-29" />
     <release version="2.76.01" date="2026-05-27" />


### PR DESCRIPTION
Flatpak metadata update for Tdarr 2.79.01.

Release date: 2026-06-21

Changes:
- Adds AppStream release metadata for Tdarr Server 2.79.01
- Adds AppStream release metadata for Tdarr Node 2.79.01