### PR TITLE
Update Flatpak metadata for 2.81.01

### DIFF
--- a/flatpak/io.tdarr.Tdarr_Node.metainfo.xml
+++ b/flatpak/io.tdarr.Tdarr_Node.metainfo.xml
@@ -25,6 +25,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="2.81.01" date="2026-06-26" />
     <release version="2.80.01" date="2026-06-22" />
     <release version="2.79.01" date="2026-06-21" />
     <release version="2.78.01" date="2026-06-12" />

--- a/flatpak/io.tdarr.Tdarr_Server.metainfo.xml
+++ b/flatpak/io.tdarr.Tdarr_Server.metainfo.xml
@@ -29,6 +29,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="2.81.01" date="2026-06-26" />
     <release version="2.80.01" date="2026-06-22" />
     <release version="2.79.01" date="2026-06-21" />
     <release version="2.78.01" date="2026-06-12" />


### PR DESCRIPTION
Flatpak metadata update for Tdarr 2.81.01.

Release date: 2026-06-26

Changes:
- Adds AppStream release metadata for Tdarr Server 2.81.01
- Adds AppStream release metadata for Tdarr Node 2.81.01