### PR TITLE
Update Flatpak metadata for 2.84.01

### DIFF
--- a/flatpak/io.tdarr.Tdarr_Node.metainfo.xml
+++ b/flatpak/io.tdarr.Tdarr_Node.metainfo.xml
@@ -25,6 +25,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="2.84.01" date="2026-07-18" />
     <release version="2.83.01" date="2026-07-12" />
     <release version="2.82.02" date="2026-07-05" />
     <release version="2.82.01" date="2026-07-04" />

--- a/flatpak/io.tdarr.Tdarr_Server.metainfo.xml
+++ b/flatpak/io.tdarr.Tdarr_Server.metainfo.xml
@@ -29,6 +29,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="2.84.01" date="2026-07-18" />
     <release version="2.83.01" date="2026-07-12" />
     <release version="2.82.02" date="2026-07-05" />
     <release version="2.82.01" date="2026-07-04" />


### PR DESCRIPTION
Flatpak metadata update for Tdarr 2.84.01.

Release date: 2026-07-18

Changes:
- Adds AppStream release metadata for Tdarr Server 2.84.01
- Adds AppStream release metadata for Tdarr Node 2.84.01