### PR TITLE
Update Flatpak metadata for 2.86.01

### DIFF
--- a/flatpak/io.tdarr.Tdarr_Node.metainfo.xml
+++ b/flatpak/io.tdarr.Tdarr_Node.metainfo.xml
@@ -25,6 +25,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="2.86.01" date="2026-08-05" />
     <release version="2.85.01" date="2026-07-24" />
     <release version="2.84.01" date="2026-07-18" />
     <release version="2.83.01" date="2026-07-12" />

--- a/flatpak/io.tdarr.Tdarr_Server.metainfo.xml
+++ b/flatpak/io.tdarr.Tdarr_Server.metainfo.xml
@@ -29,6 +29,7 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="2.86.01" date="2026-08-05" />
     <release version="2.85.01" date="2026-07-24" />
     <release version="2.84.01" date="2026-07-18" />
     <release version="2.83.01" date="2026-07-12" />


### PR DESCRIPTION
Flatpak metadata update for Tdarr 2.86.01.

Release date: 2026-08-05

Changes:
- Adds AppStream release metadata for Tdarr Server 2.86.01
- Adds AppStream release metadata for Tdarr Node 2.86.01