### PR TITLE
Add IPv6 relay for WebUI/server ports (app binds IPv4-only)

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -24,7 +24,7 @@ RUN apt-get update &&  \
     # usermod -G users Tdarr && \
 
     apt-get update && \
-    apt-get install -y curl unzip wget comskip \
+    apt-get install -y curl unzip wget comskip socat \
         # for apprise
         python3-pip && \
         pip3 install apprise && \

--- a/docker/root/etc/services.d/ipv6_relay/run
+++ b/docker/root/etc/services.d/ipv6_relay/run
@@ -1,0 +1,23 @@
+#!/usr/bin/with-contenv bash
+
+# Tdarr_Server and Tdarr_Node bind their listeners on 0.0.0.0 (IPv4-only),
+# so on IPv6-enabled docker networks the published ports are unreachable over
+# IPv6 (the container's IPv6 address has no listener). socat relays each port
+# from an IPv6-only socket to the app's IPv4 listener: ipv6only=1 makes the
+# relay socket v6-only, which coexists with the app's 0.0.0.0 bind on the
+# same port instead of colliding with it.
+
+RELAY_PORTS=""
+
+if [ -d "/etc/services.d/tdarr_server" ]; then
+    RELAY_PORTS="${WEB_UI_PORT} ${SERVER_PORT}"
+else
+    RELAY_PORTS="${NODE_PORT}"
+fi
+
+for PORT in $RELAY_PORTS; do
+    socat TCP-LISTEN:"${PORT}",bind=[::],ipv6only=1,fork,reuseaddr TCP4:127.0.0.1:"${PORT}" &
+done
+
+# s6 requires the run script to stay in the foreground; wait for the relays
+wait


### PR DESCRIPTION
Fixes #1433

## Summary

The Tdarr server binds its WebUI (8265) and server (8266) listeners on `0.0.0.0` only (confirmed via `/proc/net/tcp` inside the container — the tcp6 table is completely empty). On IPv6-enabled docker networks, published ports have no listener on the container's IPv6 address, so IPv6 clients get reset after connect while IPv4 works.

This adds an s6 service that runs a socat relay for each served port: socat binds an IPv6-only socket (`ipv6only=1`, which coexists with the app's `0.0.0.0` bind on the same port rather than colliding with it) and forks connections through to the IPv4 listener on loopback. IPv4 traffic is untouched — it still reaches the app directly.

- Server image: relays `WEB_UI_PORT` and `SERVER_PORT`
- Node image: relays `NODE_PORT` (same directory-marker check the existing `tdarr_node/run` uses)
- `socat` added to the base image deps

The app-side alternative would be binding `[::]` dual-stack in the server itself, which would make the relay unnecessary — happy to drop this if that's preferred.

## Validation

Repro environment: docker network with `enable_ipv6: true`, probing the container's own addresses directly (no port publishing in the path). Repro setup: https://github.com/Mearman/tdarr-ipv6-repro

Before (unmodified `haveagitgat/tdarr:latest`):

```
-- /proc/net/tcp (IPv4) listeners --
00000000:2049   <- 0.0.0.0:8265
00000000:204A   <- 0.0.0.0:8266
-- /proc/net/tcp6 (IPv6) listeners --
(empty)

direct IPv4 probe: 200
direct IPv6 probe: FAILED
```

After (image + this change):

```
-- /proc/net/tcp (IPv4) listeners --
00000000:2049
00000000:204A
-- /proc/net/tcp6 (IPv6) listeners --
00000000000000000000000000000000:2049
00000000000000000000000000000000:204A

direct IPv4 probe: 200
direct IPv6 probe: 200
```

Found on a Home Assistant OS host (its docker bridge is fully IPv6-enabled, every container gets a ULA address) where every other containerised app binds dual-stack and Tdarr was the only service unreachable over IPv6.
